### PR TITLE
fix: log error context and healthcheck earlier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/codebgp
-IMAGE_VERSION?=0.2.0
+IMAGE_VERSION?=0.2.1
 
 pre-commit-run-all:
 	GOARCH=amd64 CGO_ENABLED=1 pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/codebgp
-IMAGE_VERSION?=0.2.2-test
+IMAGE_VERSION?=0.2.2
 
 pre-commit-run-all:
 	GOARCH=amd64 CGO_ENABLED=1 pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/codebgp
-IMAGE_VERSION?=0.2.1
+IMAGE_VERSION?=0.2.2-test
 
 pre-commit-run-all:
 	GOARCH=amd64 CGO_ENABLED=1 pre-commit run --all-files

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queu
 	for _, event := range events {
 		msg, err := json.Marshal(event)
 		if err != nil {
-			L.Fatal("Error parsing event", zap.Error(err))
+			L.Fatal("Error serialising event", zap.Error(err))
 		}
 
 		topic := topicName(topicNamespace, event.TableName, topicVersion)
@@ -169,18 +169,18 @@ func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queu
 		} else {
 			err = p.Produce(message, deliveryChan)
 			if err != nil {
-				L.Fatal("Failed to produce", zap.Error(err))
+				L.Fatal("Failed to produce", zap.Error(err), zap.String("topic", topic))
 			}
 			e := <-deliveryChan
 
 			result := e.(*kafka.Message)
 			if result.TopicPartition.Error != nil {
-				L.Fatal("Delivery failed", zap.Error(result.TopicPartition.Error))
+				L.Fatal("Delivery failed", zap.Error(result.TopicPartition.Error), zap.String("topic", topic))
 			}
 		}
 		err = eq.MarkEventAsProcessed(event.ID)
 		if err != nil {
-			L.Fatal("Error marking record as processed", zap.Error(err))
+			L.Fatal("Error marking record as processed", zap.Error(err), zap.Int("id", event.ID))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -99,6 +99,8 @@ func main() {
 	L.Info(fmt.Sprintf("pg2kafka[commit:%s] started", Version))
 
 	// Process any events left in the queue
+	// TODO: the process cannot be abort while processing the accummulated queue.
+	// This can cause ungraceful termination of the process.
 	processQueue(producer, eq)
 
 	L.Info(fmt.Sprintf("pg2kafka[commit:%s] is now listening to notifications", Version))

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 	}()
 
 	// Setup healthcheck provider and gracefully stop
-	healthcheck.EnableProvider(healthcheck.NeverFailHealthCheck, done)
+	_ = healthcheck.EnableProvider(healthcheck.NeverFailHealthCheck, done)
 	L.Info(fmt.Sprintf("pg2kafka[commit:%s] started", Version))
 
 	// Process any events left in the queue


### PR DESCRIPTION
This PR contains 2 changes:
1. Provides context to error logging on process start
2. Enables healthchecking earlier than starting to process the queue, in order to properly respond to health probe, when a long unprocessed events queue has accumulated.